### PR TITLE
Added picard insert size metrics to Post-Mapping QC

### DIFF
--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -806,11 +806,16 @@ def insertSizeMetricsAndHistograms(infile, outfiles):
                        rm %(picard_out)s;
                     ''' % locals()
 
-        P.run()
-
     else:
+        picard_summary, picard_histogram = outfiles
+
         statement = '''echo "Not compatible with SE data"
-                       > %(outfile)s'''
+                       > %(picard_summary)s;
+                       checkpoint;
+                       echo "Not compatible with SE data"
+                       > %(picard_histogram)s
+                    ''' % locals()
+    P.run()
 
 
 @merge(insertSizeMetricsAndHistograms,
@@ -829,7 +834,9 @@ def loadInsertSizeMetrics(infiles, outfile):
 
     else:
         statement = '''echo "Not compatible with SE data"
-                       > %(outfile)s'''
+                       > %(outfile)s
+                    ''' % locals()
+        P.run()
 
 
 @merge(insertSizeMetricsAndHistograms,
@@ -848,7 +855,9 @@ def loadInsertSizeHistograms(infiles, outfile):
 
     else:
         statement = '''echo "Not compatible with SE data"
-                       > %(outfile)s'''
+                       > %(outfile)s
+                    ''' % locals()
+        P.run()
 
 
 # -------------- No. reads mapping to spike-ins vs genome ------------------- #
@@ -1053,7 +1062,7 @@ def qcSummary(infiles, outfile):
                               PCT_READS_ALIGNED_IN_PAIRS
                                        as pct_reads_aligned_in_pairs,
                               MEDIAN_INSERT_SIZE
-                                       as median_insert_size
+                                       as median_insert_size,
                            '''
         pcat = "PAIR"
 
@@ -1080,7 +1089,7 @@ def qcSummary(infiles, outfile):
                                        as three_prime_bias,
                                     nreads_uniq_map_genome,
                                     nreads_uniq_map_spike,
-                                    %(paired_columns)s,
+                                    %(paired_columns)s
                                     PCT_MRNA_BASES
                                        as percent_mrna,
                                     PCT_CODING_BASES

--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -813,7 +813,6 @@ def insertSizeMetricsAndHistograms(infile, outfiles):
                        > %(outfile)s'''
 
 
-
 @merge(insertSizeMetricsAndHistograms,
        "qc.dir/qc_insert_size_metrics.load")
 def loadInsertSizeMetrics(infiles, outfile):
@@ -823,8 +822,8 @@ def loadInsertSizeMetrics(infiles, outfile):
         picard_summaries = [x[0] for x in infiles]
 
         P.concatenateAndLoad(picard_summaries, outfile,
-                             regex_filename=(".*/.*/"
-                                             "(.*).insert.size.metrics.summary"),
+                             regex_filename=(".*/.*/(.*)"
+                                             ".insert.size.metrics.summary"),
                              cat="cell",
                              options='')
 
@@ -842,14 +841,14 @@ def loadInsertSizeHistograms(infiles, outfile):
         picard_histograms = [x[1] for x in infiles]
 
         P.concatenateAndLoad(picard_histograms, outfile,
-                             regex_filename=(".*/.*/"
-                                             "(.*).insert.size.metrics.histogram"),
+                             regex_filename=(".*/.*/(.*)"
+                                             ".insert.size.metrics.histogram"),
                              cat="cell",
                              options='-i "insert_size" -e')
 
     else:
-    statement = '''echo "Not compatible with SE data"
-                   > %(outfile)s'''
+        statement = '''echo "Not compatible with SE data"
+                       > %(outfile)s'''
 
 
 # -------------- No. reads mapping to spike-ins vs genome ------------------- #

--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -1019,10 +1019,16 @@ def loadSampleInformation(infile, outfile):
         loadFractionReadsSpliced,
         loadNumberGenesDetected,
         loadNumberGenesDetectedHTSeq,
-        loadAlignmentSummaryMetrics],
+        loadAlignmentSummaryMetrics,
+        loadInsertSizeMetrics],
        "qc.dir/qc_summary.txt")
 def qcSummary(infiles, outfile):
     '''create a summary table of relevant QC metrics'''
+
+    loadInsertSizes = infiles[-1]
+    insert_size_summary = loadInsertSizes[0]
+    infiles.pop()
+    infiles.append(insert_size_summary)
 
     # Some QC metrics are specific to paired end data
     if PAIRED:
@@ -1038,6 +1044,7 @@ def qcSummary(infiles, outfile):
         optional_columns = ''
         pcat = "UNPAIRED"
 
+    print infiles
     tables = [P.toTable(x) for x in infiles
               if P.toTable(x) not in exclude]
 
@@ -1121,7 +1128,7 @@ def notebooks(infile, outfile):
     shutil.copy(infile, outfile)
 
 
-@follows(quantitation, qc, notebooks, loadInsertSizeMetrics)
+@follows(quantitation, qc, notebooks)
 def full():
     pass
 

--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -1044,7 +1044,6 @@ def qcSummary(infiles, outfile):
         optional_columns = ''
         pcat = "UNPAIRED"
 
-    print infiles
     tables = [P.toTable(x) for x in infiles
               if P.toTable(x) not in exclude]
 

--- a/pipelines/pipeline_scrnaseq/pipeline.ini
+++ b/pipelines/pipeline_scrnaseq/pipeline.ini
@@ -114,6 +114,7 @@ memory=2G
 alignmentsummarymetrics_options=
 collectrnaseqmetrics_options=
 estimatelibrarycomplexity_options=
+insertsizemetric_options=
 
 [qcthresholds]
 


### PR DESCRIPTION
- generates histogram data table and pdf (histogram data table loaded into db)
- generates insert size metrics summary (loaded into db)
- median insert size is added to qc_summary 
