### PR TITLE
Add task to build transcript annotations table for Salmon

### DIFF
--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -761,33 +761,33 @@ def loadCopyNumber(infiles, outfile):
 # For salmon quantification we now use the full set of ensembl cdnas and ncrnas
 #
 # As the CGAT pipeline_geneset.py removes annotations for transcripts mapping
-# to mitocondrial contigs and scaffolds it is necessary to prepare an annotation table
+# to mitocondrial contigs and scaffolds an annotation table is first prepared.
 
 @follows(mkdir("annotations.dir"))
 @files(PARAMS["salmon_annotations"],
        "annotations.dir/transcript_info.tsv.gz")
 def salmonAnnotations(infile, outfile):
-       '''Prepare an annotation table containing information for all
-       transcripts quantified by Salmon'''
+    '''Prepare an annotation table containing information for all
+    transcripts quantified by Salmon'''
 
-       job_memory = "10G"
+    job_memory = "10G"
 
-       statement = '''zcat %(infile)s
-                      | cgat gtf2tsv -f
-                      | gzip -c
-                      > %(outfile)s'''
+    statement = '''zcat %(infile)s
+                   | cgat gtf2tsv -f
+                   | gzip -c
+                   > %(outfile)s'''
 
-       P.run()
+    P.run()
+
 
 @transform(salmonAnnotations,
            suffix(".tsv.gz"),
            ".load")
 def loadSalmonAnnotations(infile, outfile):
-       '''load the annotations for salmon'''
+    '''load the annotations for salmon'''
 
-       # will use ~15G RAM
-       P.load(infile, outfile, options = '-i "gene_id" -i "transcript_id"')
-
+    # will use ~15G RAM
+    P.load(infile, outfile, options='-i "gene_id" -i "transcript_id"')
 
 
 @active_if(PARAMS["salmon_active"])

--- a/pipelines/pipeline_scrnaseq/pipeline.ini
+++ b/pipelines/pipeline_scrnaseq/pipeline.ini
@@ -161,7 +161,10 @@ standards=0
 [salmon]
 active=0
 threads=4
+# e.g./gfs/mirror/genomes/salmon/mm10_ensembl91_cdna_and_ncrna.quasi.31
 index=
+# e.g./gfs/mirror/ensembl/mm10/Mus_musculus.GRCm38.91.gtf.gz
+annotations=
 params=
 
 [featurecounts]


### PR DESCRIPTION
Neccessary because pipeline_genesets will remove transcripts mappint to scaffolds and the mitochondrial genome.