### PR TITLE
Added job memory option to loading of transcript TPM table

### DIFF
--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -1012,7 +1012,8 @@ def loadSalmonTPMs(infile, outfile):
 
     opts = "-i " + id_name
 
-    P.load(infile, outfile, options=opts)
+    P.load(infile, outfile, options=opts,
+           job_memory=PARAMS["sql_himem"])
 
 
 # For summarisation of Salmon counts, downstream use of


### PR DESCRIPTION
This is only useful if P.load is run on a cluster node.