### PR TITLE
Generate salmon index as part of the pipeline (settings can be specified in pipeline.yml)

### DIFF
--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -333,11 +333,6 @@ if ENSEMBL_VERSION not in PARAMS["annotations_ensembl_geneset"]:
     raise ValueError("annotations geneset does not contain the"
                      " given ensembl version number")
 
-# if (PARAMS["annotations_geneset"] == "ensembl" and
-#         ENSEMBL_VERSION not in PARAMS["salmon_index"]):
-#     raise ValueError("salmon index does not contain the"
-#                      " given ensembl version number")
-
 if (PARAMS["annotations_geneset"] == "ensembl" and
         ENSEMBL_VERSION not in PARAMS["hisat_index"]):
     raise ValueError("hisat index does not contain the"
@@ -347,10 +342,6 @@ if (PARAMS["annotations_geneset"] == "ensembl" and
 # genome name
 
 GENOME_NAME = PARAMS["annotations_genome"]
-
-# if GENOME_NAME not in PARAMS["salmon_index"]:
-#     raise ValueError("salmon index does not contain the"
-#                      " given genome name")
 
 if GENOME_NAME not in PARAMS["hisat_index"]:
     raise ValueError("hisat_index does not contain the"

--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -531,7 +531,7 @@ SALMON_INDEX = os.path.join("annotations.dir", SALMON_INDEX_NAME)
 @active_if(PARAMS["input_type"] == "fastq")
 @follows(mkdir("annotations.dir"), checkContigs)
 @files(QUANTITATION_GTF,
-              "annotations.dir/salmon_build.log")
+       "annotations.dir/salmon_build.log")
 def generateSalmonIndex(infile, outfile):
     '''Generate salmon index from annotation gtf. '''
     genome_fasta = os.path.join(PARAMS["annotations_genome_dir"],

--- a/pipelines/pipeline_scrnaseq.py
+++ b/pipelines/pipeline_scrnaseq.py
@@ -521,21 +521,22 @@ def checkContigs(infiles, outfile):
 # #################### Generate salmon index ################################ #
 # ########################################################################### #
 
-SALMON_INDEX_NAME = ".".join([os.path.basename(QUANTITATION_GTF[:-len(".gtf.gz")]),
-                           PARAMS["salmon_index_type"],
-                           str(PARAMS["salmon_index_k"])])
+SALMON_INDEX_NAME = ".".join(
+    [os.path.basename(QUANTITATION_GTF[:-len(".gtf.gz")]),
+     PARAMS["salmon_index_type"],
+     str(PARAMS["salmon_index_k"])])
 SALMON_INDEX = os.path.join("annotations.dir", SALMON_INDEX_NAME)
+
 
 @active_if(PARAMS["input_type"] == "fastq")
 @follows(mkdir("annotations.dir"), checkContigs)
 @files(QUANTITATION_GTF,
               "annotations.dir/salmon_build.log")
 def generateSalmonIndex(infile, outfile):
-
+    '''Generate salmon index from annotation gtf. '''
     genome_fasta = os.path.join(PARAMS["annotations_genome_dir"],
                                 PARAMS["annotations_genome_fasta"])
     index_folder = SALMON_INDEX
-
     job_memory = PARAMS["salmon_index_memory"]
     statement = '''fasta_out=`mktemp -p %(cluster_tmpdir)s`;
             gtf=`mktemp -p %(cluster_tmpdir)s`;
@@ -552,7 +553,6 @@ def generateSalmonIndex(infile, outfile):
             -k %(salmon_index_k)s
             &> %(outfile)s '''
     P.run(statement)
-
 
 
 # ########################################################################### #
@@ -1012,7 +1012,6 @@ def salmon(infiles, outfile):
 
     else:
         reads_one = [reads_one]
-
 
     if PAIRED:
         reads_two = [x[:-len(".1.gz")] + ".2.gz" for x in reads_one]

--- a/pipelines/pipeline_scrnaseq/pipeline.yml
+++ b/pipelines/pipeline_scrnaseq/pipeline.yml
@@ -201,8 +201,9 @@ salmon:
     # recommended k is 31
     index_k: 31
     index_memory: 10000M
-    # --keepDuplicates can set here or not
-    index_options:
+    # By default, we keep the duplicate transcripts
+    # when generating a salmon index
+    index_options: --keepDuplicates
 
     # The source of mappings between transcript_id and gene_id
     # (1) "ensembl" to use the annotations_ensembl_dataset above (recommended)

--- a/pipelines/pipeline_scrnaseq/pipeline.yml
+++ b/pipelines/pipeline_scrnaseq/pipeline.yml
@@ -116,6 +116,9 @@ annotations:
     # location of the plain genome sequence
     genome_dir: /gfs/mirror/ensembl/genomes/plain
 
+    # genome fasta file located in genome_dir
+    genome_fasta: GRCm38.fasta
+
     # Either "ensembl" or "ucsc"
     # !! used to sanity check contig names in
     # the plain genone, geneset, and Hisat2 index !!
@@ -193,7 +196,13 @@ salmon:
     #
     # human: /gfs/mirror/ensembl/genomes/salmon/GRCh38.91.quasi.31/
     # mouse: /gfs/mirror/ensembl/genomes/salmon/GRCm38.91.quasi.31/
-    index: /gfs/mirror/ensembl/genomes/salmon/GRCm38.91.quasi.31/
+    # index: /gfs/mirror/ensembl/genomes/salmon/GRCm38.91.quasi.31/
+    index_type: quasi
+    # recommended k is 31
+    index_k: 31
+    index_memory: 10000M
+    # --keepDuplicates can set here or not
+    index_options:
 
     # The source of mappings between transcript_id and gene_id
     # (1) "ensembl" to use the annotations_ensembl_dataset above (recommended)


### PR DESCRIPTION
Currently the indeces are created WITHOUT duplicated transcripts by default. If duplicated transcripts should be kept, add '--keepDuplicates' to salmon index options in pipeline.yml.